### PR TITLE
upgrade msgpack to 1.0.0

### DIFF
--- a/cachy/serializers/msgpack_serializer.py
+++ b/cachy/serializers/msgpack_serializer.py
@@ -10,7 +10,7 @@ from .serializer import Serializer
 
 class MsgPackSerializer(Serializer):
     """
-    Serializer that uses `msgpack <https://pypi.python.org/pypi/msgpack-python/>`_ representations.
+    Serializer that uses `msgpack <https://pypi.python.org/pypi/msgpack/>`_ representations.
 
     By default, this serializer does not support serializing custom objects.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ packages = [
 python = "~2.7 || ^3.4"
 redis = { version = "^3.3.6", optional = true }
 python-memcached = { version = "^1.59", optional = true }
-msgpack-python = { version = "^0.5", optional = true }
+msgpack = { version = "^1.0.0", optional = true }
 
 [tool.poetry.extras]
 redis = ["redis"]
 memcached = ["python-memcached"]
-msgpack = ["msgpack-python"]
+msgpack = ["msgpack"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.6"


### PR DESCRIPTION
This is a PR to update the dependency away from the deprecated msgpack-python dependency. It addresses issue #13