### PR TITLE
Distribute tests in sdist via `include`, not `packages`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,8 @@ homepage = "https://github.com/sdispater/cachy"
 repository = "https://github.com/sdispater/cachy"
 keywords = ['cache']
 
-packages = [
-    {include = "cachy"},
-    {include = "tests", format = "sdist"},
-]
+packages = [{include = "cachy"}]
+include = [{ path = "tests", format = "sdist" }]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.4"


### PR DESCRIPTION
Resolves #9.  Moves `tests` from the `package` specifier to `include`, thereby preventing it from being installed as a global module via `setup.py`.
