### PR TITLE
No need to teardown flexmock (support 0.11.0)

### DIFF
--- a/tests/stores/test_dict_store.py
+++ b/tests/stores/test_dict_store.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from unittest import TestCase
-from flexmock import flexmock, flexmock_teardown
+from flexmock import flexmock
 
 from cachy.stores import DictStore
 
 
 class DictStoreTestCase(TestCase):
-
-    def tearDown(self):
-        flexmock_teardown()
 
     def test_items_can_be_set_and_retrieved(self):
         store = DictStore()

--- a/tests/stores/test_file_store.py
+++ b/tests/stores/test_file_store.py
@@ -7,7 +7,7 @@ import hashlib
 import shutil
 
 from unittest import TestCase
-from flexmock import flexmock, flexmock_teardown
+from flexmock import flexmock
 
 from cachy.serializers import JsonSerializer
 from cachy.stores import FileStore
@@ -28,8 +28,6 @@ class DictStoreTestCase(TestCase):
         for e in glob.glob(os.path.join(self._dir, '*')):
             if os.path.isdir(e):
                 shutil.rmtree(e)
-
-        flexmock_teardown()
 
     def test_none_is_returned_if_file_doesnt_exist(self):
         mock = flexmock(os.path)

--- a/tests/stores/test_redis_store.py
+++ b/tests/stores/test_redis_store.py
@@ -4,7 +4,6 @@ import math
 
 import redis
 from unittest import TestCase
-from flexmock import flexmock, flexmock_teardown
 from fakeredis import FakeServer
 from fakeredis import FakeStrictRedis
 from cachy.stores import RedisStore
@@ -23,7 +22,6 @@ class RedisStoreTestCase(TestCase):
         super(RedisStoreTestCase, self).setUp()
 
     def tearDown(self):
-        flexmock_teardown()
         self.redis.flushdb()
 
     def test_get_returns_null_when_not_found(self):

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -3,7 +3,7 @@
 import os
 import tempfile
 from unittest import TestCase
-from flexmock import flexmock, flexmock_teardown
+from flexmock import flexmock
 
 from cachy import CacheManager, Repository
 from cachy.stores import DictStore, FileStore
@@ -11,9 +11,6 @@ from cachy.contracts.store import Store
 
 
 class RepositoryTestCase(TestCase):
-
-    def tearDown(self):
-        flexmock_teardown()
 
     def test_store_get_the_correct_store(self):
         cache = CacheManager({

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -2,16 +2,13 @@
 
 import datetime
 from unittest import TestCase
-from flexmock import flexmock, flexmock_teardown
+from flexmock import flexmock
 
 from cachy import Repository
 from cachy.contracts.store import Store
 
 
 class RepositoryTestCase(TestCase):
-
-    def tearDown(self):
-        flexmock_teardown()
 
     def test_get_returns_value_from_cache(self):
         repo = self._get_repository()

--- a/tests/test_tagged_cache.py
+++ b/tests/test_tagged_cache.py
@@ -7,13 +7,10 @@ from cachy.stores import DictStore, RedisStore
 from cachy.tag_set import TagSet
 from cachy.redis_tagged_cache import RedisTaggedCache
 from datetime import datetime, timedelta
-from flexmock import flexmock, flexmock_teardown
+from flexmock import flexmock
 
 
 class TaggedCacheTestCase(TestCase):
-
-    def tearDown(self):
-        flexmock_teardown()
 
     def test_tags_can_be_flushed(self):
         store = DictStore()


### PR DESCRIPTION
flexmock patches unittest to hook tearing down, itself.

The `flexmock_teardown()` function is a private API that was moved in 0.11.0.